### PR TITLE
docs: fix the Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,17 @@ download. Notarizing requires Apple's $99/year Developer ID certificate, and Arr
 
 Pick whichever route you prefer. Both are one-time.
 
-### Homebrew (no Gatekeeper prompt)
+### Homebrew
 
 ```bash
 brew tap yashashwi-s/tap
-brew install --cask --no-quarantine arras
+brew install --cask arras
+xattr -dr com.apple.quarantine /Applications/Arras.app
 ```
 
-`--no-quarantine` is what skips the prompt: Homebrew tells macOS the download is trusted, so
-the app opens straight away.
+Homebrew 6 removed the `--no-quarantine` flag that used to skip the prompt outright, and
+there is no replacement — casks are quarantined unconditionally now. The third line clears
+the flag, so Arras opens without the dialog. Skip it and you get the prompt described below.
 
 ### Direct download
 
@@ -181,7 +183,7 @@ None of the competitors offer Arras's workflow integration. Pin a photo above al
 ## System Requirements
 
 - macOS 14.0 Sonoma or later
-- Apple Silicon or Intel Mac
+- Apple Silicon. The released build is arm64-only; building from source works on Intel
 
 ## Building from Source
 


### PR DESCRIPTION
Companion to yashashwi-s/homebrew-tap#1, which sets up the `arras` cask.

## The documented command no longer works

```
$ brew install --cask --no-quarantine arras
Error: invalid option: --no-quarantine
```

Homebrew 6 removed the flag. There is no replacement — no env-var opt-out, and nothing left in `Library/Homebrew` that lets a cask or a user decline quarantine. I confirmed it both ways: the flag errors out, and a cask installed without it comes out carrying `com.apple.quarantine: 0181;...;Homebrew Cask;...`.

So the "Homebrew (no Gatekeeper prompt)" heading is no longer achievable at install time. The README now installs and then clears the attribute, which is the same one-time step by a different route.

## Architecture claim was wrong

`lipo -archs` on the v2.4.4 release DMG returns `arm64` alone, not a universal binary. The README promised Intel support that the shipped artifact does not have — an Intel user following it downloads an app that cannot launch.

The new cask declares `depends_on arch: :arm64` so Homebrew refuses cleanly rather than installing something broken, and this makes the README agree with it.

**If universal builds were the intent, this line is the wrong fix** — the release workflow builds without pinning `ARCHS`, and that is where it should be corrected instead. Happy to switch it over; I did not want to change what ships without asking.

## Not verified by build

Docs-only change, no Swift touched, so `./build.sh` was not re-run. The claims above were checked against the actual v2.4.4 artifact and a live Homebrew 6.0.11 rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)